### PR TITLE
getElementByValue now returns the element and the index

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -124,7 +124,7 @@ function MenuData.Open(type, namespace, name, data, submit, cancel, change, clos
     menu.getElementByValue                = function(value)
         for i = 1, #menu.data.elements, 1 do
             if menu.data.elements[i].value == value then
-                return menu.data.elements[i]
+                return menu.data.elements[i], i
             end
         end
     end

--- a/version
+++ b/version
@@ -1,4 +1,5 @@
-
+<1.1>
+- getElementByValue now returns the element and the index of the element
 <1.0>
 - added last selected tracker tab
 - added new defined variables to build menus with grids


### PR DESCRIPTION
I hope it is sufficient if I refer to the [PR #141](https://github.com/VORPCORE/vorp_character-lua/pull/141) from vorp_character.